### PR TITLE
fix: support nested context

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12, 14]
+        node-version: [ 16, 18 ]
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/src/parser/PairMaker.js
+++ b/src/parser/PairMaker.js
@@ -69,17 +69,44 @@ const PAIR_MARKS = [
     }
 ];
 
+// create entries
+// [start.key, mark]
+// [end.key, mark]
+const PAIR_MARKS_ENTRIES = PAIR_MARKS.map(mark => {
+    return [
+        [mark.start, mark],
+        [mark.end, mark]
+    ];
+}).flat(1);
+
+/**
+ * Optimized Map
+ * @type Map<string, {key:string,start:string,end:string}>
+ */
+const PAIR_MARKS_KEY_Map = new Map(PAIR_MARKS_ENTRIES);
+const matchPair = (string) => {
+    return PAIR_MARKS_KEY_Map.get(string);
+}
 // For readme
 // console.log(PAIR_MARKS.map(pair => `- ${pair.key}: \`${pair.start}\` and \`${pair.end}\``).join("\n"));
 export class PairMaker {
+    /**
+     * @param {import("./SourceCode").SourceCode} sourceCode 
+     * @returns 
+     */
     mark(sourceCode) {
         const string = sourceCode.read();
         if (!string) {
             return;
         }
-        // if current is in a context, should not start other context.
-        // PairMaker does not support nest context by design.
-        if (sourceCode.isInContext()) {
+
+        const matchedPair = matchPair(string)
+        if (!matchedPair){
+            return;
+        }
+        // support nested pair
+        // {"{test}"}
+        if (sourceCode.isInContext(matchedPair)) {
             // check that string is end mark?
             const pair = PAIR_MARKS.find(pair => pair.end === string);
             if (pair) {

--- a/test/textlint-rule-no-unmatched-pair-test.js
+++ b/test/textlint-rule-no-unmatched-pair-test.js
@@ -7,6 +7,7 @@ const rule = require("../src/textlint-rule-no-unmatched-pair.js");
 // ruleName, rule, { valid, invalid }
 tester.run("textlint-rule-no-unmatched-pair", rule, {
     valid: [
+        `{"{ABC}"}`,
         "これは(秘密)です。",
         `John said "Hello World!".`,
         "`(` is ok.", "文字列リテラルには3種類ありますが、まずは`\"`（ダブルクオート）と`'`（シングルクオート）について見ていきます。",

--- a/test/textlint-rule-no-unmatched-pair-test.js
+++ b/test/textlint-rule-no-unmatched-pair-test.js
@@ -8,6 +8,7 @@ const rule = require("../src/textlint-rule-no-unmatched-pair.js");
 tester.run("textlint-rule-no-unmatched-pair", rule, {
     valid: [
         `{"{ABC}"}`,
+        'test {"{ABC`{"{ABC}"}`}"} ok.',
         "これは(秘密)です。",
         `John said "Hello World!".`,
         "`(` is ok.", "文字列リテラルには3種類ありますが、まずは`\"`（ダブルクオート）と`'`（シングルクオート）について見ていきます。",


### PR DESCRIPTION
Support nest pair like `{"{ABC}"}`

Require Node.js 12+, but it already droppped Node 10
https://node.green/#ES2019-features-Array-prototype--flat--flatMap-

fix #14 