### PR TITLE
Fix the error message

### DIFF
--- a/src/textlint-rule-no-unmatched-pair.js
+++ b/src/textlint-rule-no-unmatched-pair.js
@@ -39,10 +39,10 @@ const report = (context) => {
                         report(
                             node,
                             new RuleError(
-                                `Not found pair character for ${contextLocation.pairMark.start}.
+                                `Cannot find a pairing character for ${contextLocation.pairMark.start}.
                     
 You should close this sentence with ${contextLocation.pairMark.end}.
-This pair mark is called ${contextLocation.pairMark.key}.`,
+This pair of marks is called ${contextLocation.pairMark.key}.`,
                                 {
                                     index: sentenceIndex - node.range[0] + contextLocation.index
                                 }

--- a/test/textlint-rule-no-unmatched-pair-test.js
+++ b/test/textlint-rule-no-unmatched-pair-test.js
@@ -47,10 +47,10 @@ tester.run("textlint-rule-no-unmatched-pair", rule, {
             errors: [
                 {
                     index: 4,
-                    message: `Not found pair character for （.
+                    message: `Cannot find a pairing character for （.
                     
 You should close this sentence with ）.
-This pair mark is called 丸括弧（）.`
+This pair of marks is called 丸括弧（）.`
                 }
             ]
         },
@@ -59,10 +59,10 @@ This pair mark is called 丸括弧（）.`
             errors: [
                 {
                     index: 11,
-                    message: `Not found pair character for ".
+                    message: `Cannot find a pairing character for ".
                     
 You should close this sentence with ".
-This pair mark is called double quote.`
+This pair of marks is called double quote.`
                 }
             ]
         },


### PR DESCRIPTION
- 文字「が」見つかる (名詞 + be found) / 文字「を」見つける (find + 名詞) のどちらかであるべきなので、このような際のエラーメッセージに典型的に用いられる "Cannot find + 名詞" と表現。
- 両者を見せるエラーメッセージは This pair of (punctuation) marks などとするのがよい（cf. https://en.wikipedia.org/wiki/Guillemet ）ので、その旨修正。